### PR TITLE
allow "_local" as a node name

### DIFF
--- a/es_stats/es_stats.py
+++ b/es_stats/es_stats.py
@@ -5,6 +5,7 @@ from .exceptions import *
 from .utils import *
 import re
 import logging
+import socket
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,10 @@ class NodeStats():
         for node in self.rawstats["nodes"]:
             if self.rawstats["nodes"][node]["name"] == self.nodename:
                 self.nodeid = node
+        if self.nodename == '_local':
+            my_ip = socket.gethostbyname(socket.gethostname())
+            for node in self.rawstats["nodes"]:
+                if self.rawstats["nodes"][node]["host"] == my_ip:
         if not self.nodeid:
             raise NotFound('Node with name {0} not found.'.format(self.nodename))
         self.stats = DotMap(self.rawstats["nodes"][self.nodeid])
@@ -79,6 +84,10 @@ class NodeInfo():
         for node in self.rawinfo["nodes"]:
             if self.rawinfo["nodes"][node]["name"] == self.nodename:
                 self.nodeid = node
+        if self.nodename == '_local':
+            my_ip = socket.gethostbyname(socket.gethostname())
+            for node in self.rawstats["nodes"]:
+                if self.rawstats["nodes"][node]["host"] == my_ip:
         if not self.nodeid:
             raise NotFound('Node with name {0} not found.'.format(self.nodename))
         self.info = DotMap(self.rawinfo["nodes"][self.nodeid])

--- a/es_stats/es_stats.py
+++ b/es_stats/es_stats.py
@@ -56,9 +56,18 @@ class NodeStats():
             if self.rawstats["nodes"][node]["name"] == self.nodename:
                 self.nodeid = node
         if self.nodename == '_local':
-            my_ip = socket.gethostbyname(socket.gethostname())
-            for node in self.rawstats["nodes"]:
-                if self.rawstats["nodes"][node]["host"] == my_ip:
+            my_hostname = socket.gethostname()
+            my_ip = socket.gethostbyname(my_hostname)
+            if my_ip != '127.0.0.1':
+                # great, we can use our IP to look up which host we are
+                for node in self.rawstats["nodes"]:
+                    if self.rawstats["nodes"][node]["host"] == my_ip:
+                        self.nodeid = node
+            else:
+                # fall back to looking up the names of all the hosts instead
+                for node in self.rawstats["nodes"]:
+                    if socket.gethostbyaddr(self.rawstats["nodes"][node]["host"])[0] == my_hostname:
+                        self.nodeid = node
         if not self.nodeid:
             raise NotFound('Node with name {0} not found.'.format(self.nodename))
         self.stats = DotMap(self.rawstats["nodes"][self.nodeid])
@@ -85,9 +94,18 @@ class NodeInfo():
             if self.rawinfo["nodes"][node]["name"] == self.nodename:
                 self.nodeid = node
         if self.nodename == '_local':
-            my_ip = socket.gethostbyname(socket.gethostname())
-            for node in self.rawstats["nodes"]:
-                if self.rawstats["nodes"][node]["host"] == my_ip:
+            my_hostname = socket.gethostname()
+            my_ip = socket.gethostbyname(my_hostname)
+            if my_ip != '127.0.0.1':
+                # great, we can use our IP to look up which host we are
+                for node in self.rawstats["nodes"]:
+                    if self.rawstats["nodes"][node]["host"] == my_ip:
+                        self.nodeid = node
+            else:
+                # fall back to looking up the names of all the hosts instead
+                for node in self.rawstats["nodes"]:
+                    if socket.gethostbyaddr(self.rawstats["nodes"][node]["host"])[0] == my_hostname:
+                        self.nodeid = node
         if not self.nodeid:
             raise NotFound('Node with name {0} not found.'.format(self.nodename))
         self.info = DotMap(self.rawinfo["nodes"][self.nodeid])


### PR DESCRIPTION
ES supports a special node name ("_local"), which always refers to the local node.

https://www.elastic.co/guide/en/elasticsearch/reference/2.2/cluster.html#cluster-nodes

Example: curl localhost:9200/_nodes/_local/stats?pretty

This change allows "_local" to be specified instead of a specific ES node name for both nodestats and nodeinfo requests.

The end effect of this is that you no longer have to know the ES node name in order to get stats for the local system. This greatly simplifies the usage of es_stats_zabbix in conjunction with Zabbix monitoring templates, because Zabbix no longer needs to know this bit of information, and thus every ES node can have the same monitoring config in its template.

(I will send a separate PR to the es_stats_zabbix project which includes a more complete Zabbix template that makes use of this change.)

The only caveat here is that we need some way to figure out which node in the client.nodes.stats() output is the local node. This patch tries 2 different ways to figure that out. First, we just look up our own IP and search for that in the node list. If our own IP is returned as "127.0.0.1" (common in some linux distros, depending on what /etc/hosts looks like), we use our hostname instead and compare that to the hostnames of the IPs of everything in the node list.

None of this happens unless the given name is "_local", so we incur no new overhead for any existing use cases.